### PR TITLE
Atualiza link para o kycnot.me

### DIFF
--- a/05-kyc-sai-fora/index.html
+++ b/05-kyc-sai-fora/index.html
@@ -570,7 +570,7 @@
 					</table>
 <p><br>
 					<center><font color="#fff">Este conteúdo serve apenas como referência. Verifique as informações antes de executar qualquer ação.
-						<br>Fork do <a href="https://github.com/pluja/kycnot" target="_blank">KYCNOT.me</a>. Traduzido e alterado para os <a href="https://www.twitter.com/bitcoinheiros" target="_blank">bitcoinheiros</a> por <a href="https://www.twitter.com/bitdov" target="_blank">bitdov</a></font></center></p>
+						<br>Fork do <a href="https://gitlab.com/kycnot/kycnot.me" target="_blank">KYCNOT.me</a>. Traduzido e alterado para os <a href="https://www.twitter.com/bitcoinheiros" target="_blank">bitcoinheiros</a> por <a href="https://www.twitter.com/bitdov" target="_blank">bitdov</a></font></center></p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Segundo [o repositório original no GitHub](https://github.com/pluja/kycnot?tab=readme-ov-file#this-repository-has-moved-here), eles se moveram para o GitLab https://gitlab.com/kycnot/kycnot.me